### PR TITLE
`get-dependencies.sh`: Fix minor syntax error when installing package…

### DIFF
--- a/scripts/get-dependencies.sh
+++ b/scripts/get-dependencies.sh
@@ -9,7 +9,7 @@ echo "---------------------------------------------------------------"
 pacman -Syu --noconfirm  \
             python       \
             nss          \
-            at-spi2-core \
+            at-spi2-core
           
 
 


### PR DESCRIPTION
… dependencies