### PR TITLE
chore: Improve loading speed of Applications and Installed data

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ const SANDBOX_DIR_KEYS = ['desktop', 'documents', 'downloads', 'games', 'music',
 const SANDBOX_MARKER = 'aisap-am sandboxing script';
 
 const iconCacheManager = createIconCacheManager(app);
-registerCategoryHandlers(ipcMain);
+registerCategoryHandlers(ipcMain, app.getPath('userData'));
 
 // --- Single instance lock ---
 const gotTheLock = app.requestSingleInstanceLock();

--- a/main.js
+++ b/main.js
@@ -898,16 +898,54 @@ ipcMain.handle('list-apps-detailed', async () => {
   // the actual list of installed programs. Run both and merge results.
   const listCmd = `${pm} -l`;
   const installedCmd = `${pm} -f`;
-  const execPromise = (cmd) => new Promise(res => {
-    exec(cmd, (err, stdout) => res({ err, stdout: stdout || '' }));
-  });
   return new Promise(async (resolve) => {
+    let listRes, instRes;
+    let tmpDir1, tmpDir2;
     try {
-      // Run sequentially — not in parallel — because both `am -l` and `am -f`
-      // share the same $AMCACHEDIR/version-args cache file. Running them
-      // concurrently causes one to delete the cache while the other reads it.
-      const listRes = await execPromise(listCmd);
-      const instRes = await execPromise(installedCmd);
+      // appman sets AMCACHEDIR="$CACHEDIR/$AMCLI" where CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}".
+      // The AMCACHEDIR env var is IGNORED (overwritten at script line 270), so we must
+      // use XDG_CACHE_HOME to redirect.  Each parallel exec gets its own XDG_CACHE_HOME
+      // pointing to an isolated temp copy of the cache dir.
+      // In AppImage, HOST_XDG_CACHE_HOME holds the host's real value.
+      const realXdgCacheHome = process.env.HOST_XDG_CACHE_HOME || process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+      const realPmCacheDir = path.join(realXdgCacheHome, pm);
+
+      tmpDir1 = fs.mkdtempSync(path.join(os.tmpdir(), 'amc-' + pm + '-l-'));
+      fs.mkdirSync(path.join(tmpDir1, pm), { recursive: true });
+      tmpDir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'amc-' + pm + '-f-'));
+      fs.mkdirSync(path.join(tmpDir2, pm), { recursive: true });
+
+      if (fs.existsSync(realPmCacheDir)) {
+        const entries = fs.readdirSync(realPmCacheDir);
+        for (const entry of entries) {
+          if (entry.endsWith('.tmp')) continue;
+          const src = path.join(realPmCacheDir, entry);
+          if (fs.statSync(src).isFile()) {
+            for (const destDir of [tmpDir1, tmpDir2]) {
+              fs.copyFileSync(src, path.join(destDir, pm, entry));
+            }
+          }
+        }
+      }
+
+      [listRes, instRes] = await Promise.all([
+        new Promise(res => exec(listCmd, { env: { ...process.env, XDG_CACHE_HOME: tmpDir1 } }, (err, stdout) => res({ err, stdout: stdout || '' }))),
+        new Promise(res => exec(installedCmd, { env: { ...process.env, XDG_CACHE_HOME: tmpDir2 } }, (err, stdout) => res({ err, stdout: stdout || '' })))
+      ]);
+
+      // Merge cache updates back — prefer the -f result (has fresh version-args + files-*).
+      for (const srcDir of [tmpDir1, tmpDir2]) {
+        const pmSrc = path.join(srcDir, pm);
+        if (fs.existsSync(pmSrc) && fs.existsSync(realPmCacheDir)) {
+          for (const entry of fs.readdirSync(pmSrc)) {
+            if (entry.endsWith('.tmp')) continue;
+            const src = path.join(pmSrc, entry);
+            if (fs.statSync(src).isFile()) {
+              fs.copyFileSync(src, path.join(realPmCacheDir, entry));
+            }
+          }
+        }
+      }
       if ((listRes.err && listRes.err.code === 127) || (instRes.err && instRes.err.code === 127)) {
         invalidatePackageManagerCache();
       }
@@ -1151,6 +1189,9 @@ ipcMain.handle('list-apps-detailed', async () => {
       return resolve({ installed, all, pmFound: true, pmName: pm, bundleChildOf });
     } catch (e) {
       return resolve({ installed: [], all: [], pmFound: true, error: tErr('errInternalParsing', 'Internal parsing error.') });
+    } finally {
+      try { if (tmpDir1) fs.rmSync(tmpDir1, { recursive: true, force: true }); } catch (_) {}
+      try { if (tmpDir2) fs.rmSync(tmpDir2, { recursive: true, force: true }); } catch (_) {}
     }
   });
 });

--- a/scripts/verify-main-modules.js
+++ b/scripts/verify-main-modules.js
@@ -34,8 +34,8 @@ let categoriesBackup = null;
   };
 
   const repoRoot = path.resolve(__dirname, '..');
-  const categoriesCachePath = path.join(repoRoot, 'categories-cache.json');
-  const categoriesMetaPath = path.join(repoRoot, 'categories-cache.meta.json');
+  let categoriesTempDir = null;
+  let categoriesCachePath, categoriesMetaPath;
 
   function snapshotCategoriesFiles() {
     return {
@@ -173,7 +173,10 @@ let categoriesBackup = null;
       }
     };
 
-    registerCategoryHandlers(ipcMain);
+    categoriesTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'am-gui-cat-test-'));
+    categoriesCachePath = path.join(categoriesTempDir, 'categories-cache.json');
+    categoriesMetaPath = path.join(categoriesTempDir, 'categories-cache.meta.json');
+    registerCategoryHandlers(ipcMain, categoriesTempDir);
     if (!ipcHandlers.has('fetch-all-categories')) throw new Error('fetch-all-categories handler missing');
 
     const firstFetch = await ipcHandlers.get('fetch-all-categories')();
@@ -213,6 +216,9 @@ let categoriesBackup = null;
     childProcess.exec = originalExec;
     undici.fetch = originalFetch;
     restoreCategoriesFiles(categoriesBackup);
+    if (categoriesTempDir && fs.existsSync(categoriesTempDir)) {
+      fs.rmSync(categoriesTempDir, { recursive: true, force: true });
+    }
     if (success) {
       process.exitCode = 0;
     }

--- a/src/main/categories.js
+++ b/src/main/categories.js
@@ -29,14 +29,6 @@ async function writeJsonSafe(filePath, data) {
   await fsp.rename(tmpPath, filePath);
 }
 
-async function updateCategoriesCache(categories) {
-  try {
-    await writeJsonSafe(categoriesCachePath, categories);
-  } catch (e) {
-    console.error('Error writing categories cache:', e);
-  }
-}
-
 async function mapWithConcurrency(limit, items, iteratorFn) {
   if (!Array.isArray(items) || !items.length) return [];
   const maxWorkers = Math.max(1, Number(limit) || 1);
@@ -78,6 +70,14 @@ function registerCategoryHandlers(ipcMain, cacheDir) {
   if (!ipcMain) throw new Error('ipcMain instance is required');
   const categoriesCachePath = path.join(cacheDir, 'categories-cache.json');
   const categoriesMetaPath = path.join(cacheDir, 'categories-cache.meta.json');
+
+  async function updateCategoriesCache(categories) {
+    try {
+      await writeJsonSafe(categoriesCachePath, categories);
+    } catch (e) {
+      console.error('Error writing categories cache:', e);
+    }
+  }
 
   ipcMain.handle('delete-categories-cache', async () => {
     try {

--- a/src/main/categories.js
+++ b/src/main/categories.js
@@ -4,9 +4,6 @@ const fs = require('fs');
 const fsp = fs.promises;
 const undici = require('undici');
 
-const projectRoot = path.resolve(__dirname, '..', '..');
-const categoriesCachePath = path.join(projectRoot, 'categories-cache.json');
-const categoriesMetaPath = path.join(projectRoot, 'categories-cache.meta.json');
 const MAX_CATEGORY_FETCH_CONCURRENCY = 6;
 
 async function readJsonSafe(filePath, fallback) {
@@ -77,8 +74,10 @@ function parseApps(markdown) {
   return apps;
 }
 
-function registerCategoryHandlers(ipcMain) {
+function registerCategoryHandlers(ipcMain, cacheDir) {
   if (!ipcMain) throw new Error('ipcMain instance is required');
+  const categoriesCachePath = path.join(cacheDir, 'categories-cache.json');
+  const categoriesMetaPath = path.join(cacheDir, 'categories-cache.meta.json');
 
   ipcMain.handle('delete-categories-cache', async () => {
     try {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -2143,6 +2143,13 @@ window.addEventListener('DOMContentLoaded', async () => {
   try {
     initMarkdownLightbox();
     initIconObserver();
+    // Ensure spinner and results are hidden at startup
+    setUpdateSpinnerBusy(false);
+    if (updateResult) updateResult.style.display = 'none';
+    // Force list view at startup
+    if (appDetailsSection) appDetailsSection.hidden = true;
+    document.body.classList.remove('details-mode');
+    if (appsDiv) appsDiv.hidden = false;
     const loadAppsPromise = loadApps();
     if (window.categories && typeof window.categories.initDropdown === 'function') {
       window.categories.initDropdown({
@@ -2186,6 +2193,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
     initLanguagePreferences();
     await loadAppsPromise;
+    // Restore any previous detail (session) if still present
+    const last = sessionStorage.getItem('lastDetailsApp');
+    if (last && (state.allApps.find(a => a.name === last) || state.allApps.find(a => (a.scope ? a.name + '|' + a.scope : a.name) === last))) {
+      showDetails(last);
+    }
     if (state.allApps && state.allApps.length > 0) {
       showToast(t('categories.allAppsCount', { count: state.allApps.length }));
     }
@@ -2701,22 +2713,8 @@ window.addEventListener('keydown', (e) => {
 
 
 
+// Handle interactive choice prompt during installation
 (async () => {
-  await loadApps();
-  // Ensure spinner and results are hidden at startup
-  setUpdateSpinnerBusy(false);
-  if (updateResult) updateResult.style.display = 'none';
-  // Force list view at startup
-  if (appDetailsSection) appDetailsSection.hidden = true;
-  document.body.classList.remove('details-mode');
-  if (appsDiv) appsDiv.hidden = false;
-  // Restore any previous detail (session) if still present
-  const last = sessionStorage.getItem('lastDetailsApp');
-  if (last && (state.allApps.find(a => a.name === last) || state.allApps.find(a => (a.scope ? a.name + '|' + a.scope : a.name) === last))) {
-    showDetails(last);
-  }
-
-  // Handle interactive choice prompt during installation
   window.electronAPI?.onInstallProgress?.((data) => {
     // Initialize install session on receiving 'start'
     if (data.kind === 'start' && data.id) {


### PR DESCRIPTION
Now `am -f` and `am -l` run in parallel again, but with isolated cache files in `/tmp`, so we get the speed improvement without cache race condition.

Additionally, it seems like loading apps was triggered twice, which made things slower. Now it's triggered only once.

I also fixed categories cache not being written in AppImage (uses config dir now instead of root directory).

It improved speed nicely for me without regressions, would be nice to test.

On the system where I have 152.24 GiB of AppImages + portable data that `am -f` needs to compute for size, improvement is huge:

8-9 seconds vs 4-5 seconds